### PR TITLE
Added libnlopt-dev to R installation for AFNI

### DIFF
--- a/neurodocker/interfaces/afni.py
+++ b/neurodocker/interfaces/afni.py
@@ -121,7 +121,7 @@ class AFNI(object):
                       "R_installer_debian_ubuntu.sh")
             cmd += ("\n# Install R"
                     "\n&& apt-get install -yq --no-install-recommends"
-                    "\n\tr-base-dev r-cran-rmpi"
+                    "\n\tr-base-dev r-cran-rmpi libnlopt-dev"
                     '\n || /bin/bash -c "'
                     '\n    curl -o /tmp/install_R.sh -sSL {}'
                     '\n    && /bin/bash /tmp/install_R.sh"'


### PR DESCRIPTION
Compilation of R, required for AFNI, was throwing an error related to libnlopt - unable to download the source. This lib is also available as a binary object via apt-get. So, instead of compiling this lib, we now download it.